### PR TITLE
Cleanup CMake 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,15 +13,19 @@ endif()
 
 # Main project library
 set(LIBRARY_NAME ${PROJECT_NAME})
-set(LIBRARY_HEADERS
-    include/mini_opt/assertions.hpp include/mini_opt/logging.hpp
-    include/mini_opt/nonlinear.hpp include/mini_opt/qp.hpp
-    include/mini_opt/residual.hpp include/mini_opt/structs.hpp)
-
 add_library(
   ${LIBRARY_NAME} STATIC
-  source/logging.cc source/nonlinear.cc source/qp.cc source/residual.cc
-  source/structs.cc ${LIBRARY_HEADERS})
+  include/mini_opt/assertions.hpp
+  include/mini_opt/logging.hpp
+  include/mini_opt/nonlinear.hpp
+  include/mini_opt/qp.hpp
+  include/mini_opt/residual.hpp
+  include/mini_opt/structs.hpp
+  source/logging.cc
+  source/nonlinear.cc
+  source/qp.cc
+  source/residual.cc
+  source/structs.cc)
 target_link_libraries(${LIBRARY_NAME} fmt::fmt-header-only eigen geometry_utils)
 target_compile_features(${LIBRARY_NAME} PUBLIC cxx_std_17)
 target_compile_options(${LIBRARY_NAME} PRIVATE ${COMPILATION_FLAGS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ add_subdirectory(dependencies)
 if(MSVC)
   set(COMPILATION_FLAGS /W4 /WX /bigobj /D_USE_MATH_DEFINES)
 else()
-  set(COMPILATION_FLAGS -Wall -Wextra -pedantic -Werror -Wno-sign-compare)
+  set(COMPILATION_FLAGS -Wall -Wextra -pedantic -Werror)
 endif()
 
 # Main project library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ add_library(
   source/qp.cc
   source/residual.cc
   source/structs.cc)
-target_link_libraries(${LIBRARY_NAME} fmt::fmt-header-only eigen geometry_utils)
+target_link_libraries(${LIBRARY_NAME} PUBLIC fmt::fmt-header-only eigen)
 target_compile_features(${LIBRARY_NAME} PUBLIC cxx_std_17)
 target_compile_options(${LIBRARY_NAME} PRIVATE ${COMPILATION_FLAGS})
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -1,26 +1,30 @@
 function(add_libfmt)
-  set(FMT_TEST
-      OFF
-      CACHE BOOL "" FORCE)
-  add_subdirectory(fmt EXCLUDE_FROM_ALL)
+  if(NOT TARGET fmt::fmt)
+    set(FMT_TEST
+        OFF
+        CACHE BOOL "" FORCE)
+    add_subdirectory(fmt EXCLUDE_FROM_ALL)
+  endif()
 endfunction()
 add_libfmt()
 
 function(add_gtest)
-  set(BUILD_GMOCK
-      OFF
-      CACHE BOOL "" FORCE)
-  set(INSTALL_GTEST
-      OFF
-      CACHE BOOL "" FORCE)
-  add_subdirectory(googletest)
+  if(NOT TARGET gtest)
+    set(BUILD_GMOCK
+        OFF
+        CACHE BOOL "" FORCE)
+    set(INSTALL_GTEST
+        OFF
+        CACHE BOOL "" FORCE)
+    add_subdirectory(googletest)
+  endif()
 endfunction()
 add_gtest()
 
 # Create a target for eigen.
 function(add_eigen)
-  set(EIGEN_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/eigen")
   if(NOT TARGET eigen)
+    set(EIGEN_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/eigen")
     add_library(eigen INTERFACE IMPORTED GLOBAL)
     set_target_properties(eigen PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
                                            "${EIGEN_INCLUDE_DIRS}")
@@ -29,9 +33,11 @@ endfunction()
 add_eigen()
 
 function(add_geometry_utils)
-  set(GEO_UTILS_BUILD_TESTING
-      OFF
-      CACHE BOOL "" FORCE)
-  add_subdirectory(geometry_utils)
+  if(NOT TARGET geometry_utils)
+    set(GEO_UTILS_BUILD_TESTING
+        OFF
+        CACHE BOOL "" FORCE)
+    add_subdirectory(geometry_utils)
+  endif()
 endfunction()
 add_geometry_utils()

--- a/include/mini_opt/residual.hpp
+++ b/include/mini_opt/residual.hpp
@@ -101,19 +101,13 @@ struct Residual : public ResidualBase {
 // Template implementations.
 //
 
-// Turn off warnings about constant if statements.
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4127)
-#endif  // _MSC_VER
-
 // Helper to read a sparse set of values out of a larger matrix.
 template <int N>
 void ReadSparseValues(const Eigen::VectorXd& input,
                       const typename internal::IndexType<N>::type& index,
                       Eigen::Matrix<double, N, 1>* output) {
   F_ASSERT(output != nullptr);
-  if (N == Eigen::Dynamic) {
+  if constexpr (N == Eigen::Dynamic) {
     output->resize(index.size());
   }
   for (std::size_t local = 0; local < index.size(); ++local) {
@@ -158,7 +152,7 @@ double Residual<ResidualDim, NumParams>::UpdateHessian(const Eigen::VectorXd& pa
 
   // Evaluate the function and its derivative.
   JacobianType J;
-  if (NumParams == Eigen::Dynamic) {
+  if constexpr (NumParams == Eigen::Dynamic) {
     J.resize(ResidualDim, index.size());
   }
   const ResidualType r = function(relevant_params, &J);
@@ -199,7 +193,7 @@ void Residual<ResidualDim, NumParams>::UpdateJacobian(
 
   // Evaluate, and copy jacobian back using indices.
   JacobianType J;
-  if (NumParams == Eigen::Dynamic) {
+  if constexpr (NumParams == Eigen::Dynamic) {
     J.resize(ResidualDim, index.size());
   }
   b_out.noalias() = function(relevant_params, &J);
@@ -210,9 +204,5 @@ void Residual<ResidualDim, NumParams>::UpdateJacobian(
     J_out.col(col_global).noalias() = J.col(col_local);
   }
 }
-
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif  // _MSC_VER
 
 }  // namespace mini_opt


### PR DESCRIPTION
- `geometry_utils` is only a test-time dependency.
- Dependencies are only added if they aren't built as part of a larger project.
- Get rid of superfluous disabling of `W4127` (not relevant in C++17 anymore).
